### PR TITLE
Added support for offline webpages

### DIFF
--- a/packaged app/manifest.json
+++ b/packaged app/manifest.json
@@ -8,6 +8,7 @@
     "email": "support@zebradog.com"
   },
   "kiosk_enabled": true,
+  "offline_enabled": true,
   "icons": {
     "16": "img/icon_16.png",
     "128": "img/icon_128.png"


### PR DESCRIPTION
Right now we are trying to access a local url eg. 192.168... and the chromebox does not have internet access but it does have local network access. When we try to launch the page, it checks for network connectivity at the start which makes the app not work. Enabling offline mode would allow this function to work.
