### PR TITLE
Add option to overwrite authorization header

### DIFF
--- a/src/js/browser.js
+++ b/src/js/browser.js
@@ -20,6 +20,7 @@ $(function(){
   var disabletouchhighlight = false;
   var disableselection = false;
   var useragent = '';
+  var authorization = '';
   var resetcache = false;
   var partition = null;
 
@@ -193,6 +194,7 @@ $(function(){
 
      defaultURL = contentURL = Array.isArray(data.url) ? data.url : [data.url];
      useragent = data.useragent;
+     authorization = data.authorization;
      if(data.multipleurlmode == 'rotate'){
         defaultURL = contentURL[urlrotateindex];
         rotaterate = data.rotaterate ? data.rotaterate : DEFAULT_ROTATE_RATE;
@@ -320,6 +322,15 @@ $(function(){
           });
         }
      });
+     $webview[0].request.onBeforeSendHeaders.addListener(
+        function(details) {
+          if (authorization) {
+            details.requestHeaders.push({name: 'Authorization', value: authorization})
+          }
+          return {requestHeaders: details.requestHeaders};
+        },
+        {urls: ["<all_urls>"]},
+        ["blocking", "requestHeaders"]);
      if(allownewwindow){
        $webview.on('newwindow',function(e){
         $('#newWindow webview').remove();

--- a/src/js/setup.js
+++ b/src/js/setup.js
@@ -157,6 +157,7 @@ $(function(){
   }
   if(data.servelocalport) $("#servelocalport").val(data.servelocalport);
   if(data.useragent) $('#useragent').val(data.useragent).siblings('label').addClass('active');
+  if(data.authorization) $('#authorization').val(data.authorization).siblings('label').addClass('active');
 
   $('select').material_select();
 
@@ -266,6 +267,7 @@ $(function(){
     var disableselection = $("#disableselection").is(':checked');
     var newwindow =  $("#newwindow").is(':checked');
     var useragent = $('#useragent').val();
+    var authorization = $('#authorization').val();
     port = port < 0 ? 0 : port;
     var username = $("#username").val();
     var password = $("#password").val();
@@ -416,6 +418,7 @@ $(function(){
       if(rotaterate) chrome.storage.local.set({'rotaterate': rotaterate});
       else chrome.storage.local.remove('rotaterate');
       chrome.storage.local.set({'useragent':useragent});
+      chrome.storage.local.set({'authorization':authorization});
       chrome.storage.local.set({'sleepmode':sleepmode});
       chrome.runtime.sendMessage('reload');
     }

--- a/src/windows/setup.html
+++ b/src/windows/setup.html
@@ -107,6 +107,13 @@
             <label for="url">Override User Agent</label>
           </div>
         </div>
+        <div class="row">
+          <div class="input-field col s12">
+            <input id="authorization" type="text">
+            <label for="url">Override Authorization</label>
+          </div>
+        </div>
+
 
         <div class="row">
           <div class="col s12">


### PR DESCRIPTION
This adds a small feature where you can set the authorization header for web requests to access secured web pages. An example use case is a dashboard that shows internal business data.

Tested it with single and multiple pages with a transition between them.