### PR TITLE
Cookies/Cache etc removal on Inactivity Reset

### DIFF
--- a/src/js/browser.js
+++ b/src/js/browser.js
@@ -22,6 +22,7 @@ $(function(){
   var useragent = '';
   var resetcache = false;
   var partition = null;
+  var clearcookies = false;
 
   $('.modal').not('#newWindow').modal();
   $('#newWindow').modal({
@@ -188,6 +189,7 @@ $(function(){
      allownewwindow = data.newwindow ? true : false
 
      reset = data.reset && parseFloat(data.reset) > 0 ? parseFloat(data.reset) : false;
+     clearcookies = data.clearcookiesreset ? true : false;
 
      if(reset) $('*').on(ACTIVE_EVENTS,active);
 
@@ -372,7 +374,7 @@ $(function(){
     }else{
       $('body').removeClass('tabbed');
     }
-    if(resetcache) partition = null;
+    if(resetcache || clearcookies) partition = null;
     if(!partition){
       partition = "persist:kiosk"+(Date.now());
       chrome.storage.local.set({'partition':partition});
@@ -421,9 +423,11 @@ $(function(){
      .data('id',id)
      .attr('src',url)
      .appendTo($webviewContainer);
-     if(resetcache) {
-       chrome.storage.local.remove('resetcache');
-       resetcache = false;
+     if(resetcache || clearcookies) {
+       if (resetcache) {
+         chrome.storage.local.remove('resetcache');
+         resetcache = false;
+       }
        var clearDataType = {
          appcache: true,
          cache: true, //remove entire cache
@@ -433,7 +437,7 @@ $(function(){
          localStorage: true,
          webSQL: true,
        };
-       $webview[0].clearData({since: 0}, clearDataType, loadContent);
+       $webview[0].clearData({since: 0}, clearDataType, resetcache ? loadContent : null);
      }
   }
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -23,7 +23,7 @@ function init() {
   /*chrome.management.getPermissionWarningsByManifest(
     JSON.stringify(chrome.runtime.getManifest()),
     function(warning){
-      console.log("PERMISSION WARNIINGS",warning);
+      console.log("PERMISSION WARNINGS",warning);
     }
   );*/
 

--- a/src/js/setup.js
+++ b/src/js/setup.js
@@ -122,6 +122,7 @@ $(function(){
     $('.reset').removeClass('disabled');
     $("#resetinterval").val(data.reset).siblings('label').addClass('active');
   }
+  if (data.clearcookiesreset) $("#clear-cookies-reset").prop("checked",true);
   if(data.restart && parseInt(data.restart)){
     var restart = parseInt(data.restart);
     $('#houroffset > option').removeAttr('selected');
@@ -258,6 +259,7 @@ $(function(){
     var restart = $("#restart").is(':checked');
     var port = parseInt($('#port').val());
     var reset = $("#reset").is(':checked');
+    var resetcookies = $('#clear-cookies-reset').is(':checked');
     var hidecursor = $("#hidecursor").is(':checked');
     var disablecontextmenu = $("#disablecontextmenu").is(':checked');
     var disabledrag = $("#disabledrag").is(':checked');
@@ -375,6 +377,8 @@ $(function(){
       }
       if(reset) chrome.storage.local.set({'reset':reset});
       else chrome.storage.local.remove('reset');
+      if (resetcookies) chrome.storage.local.set({'clearcookiesreset':resetcookies});
+      else chrome.storage.local.remove('clearcookiesreset');
       if(restart){
         restart = parseInt($('#hour').val())+parseInt($('#houroffset').val());
         chrome.storage.local.set({'restart':restart});

--- a/src/js/setup.js
+++ b/src/js/setup.js
@@ -255,7 +255,6 @@ $(function(){
     var host = $('#host').val();
     var remote = $("#remote").is(':checked');
     var local = $("#local").is(':checked');
-    var reset = $("#reset").is(':checked');
     var restart = $("#restart").is(':checked');
     var port = parseInt($('#port').val());
     var reset = $("#reset").is(':checked');

--- a/src/windows/setup.html
+++ b/src/windows/setup.html
@@ -171,6 +171,10 @@
               <div class="col input-field s8">
                 <label for="reset">minutes</label>
               </div>
+              <div class="col input-field s12">
+                <input id="clear-cookies-reset" type="checkbox" />
+                <label for="clear-cookies-reset">Clear Cookies On Reset</label>
+              </div>
             </div>
           </div>
           <div class="col s3">

--- a/src/windows/setup.html
+++ b/src/windows/setup.html
@@ -173,7 +173,7 @@
               </div>
               <div class="col input-field s12">
                 <input id="clear-cookies-reset" type="checkbox" />
-                <label for="clear-cookies-reset">Clear Cookies On Reset</label>
+                <label for="clear-cookies-reset">Clear Cookies And Cache On Reset</label>
               </div>
             </div>
           </div>


### PR DESCRIPTION
This PR aims to create a way of removing Cookies/Cache etc... once the Inactivity Reset is triggered, by providing a checkbox on the setup page, under Inactivity Reset option. 
It shares the code with "Clear Cache On Save".
Please let me know if there is anything that should be fixed before merging, or if I screwed up somewhere.

This PR closes #111 

It also fixed two super minor details. Those are on a different commit in case you prefer not to merge them
_main.js had a spelling mistake_
_setup.js had a variable defined twice_